### PR TITLE
feat(ui): up navigation block

### DIFF
--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -264,6 +264,10 @@ body {
   }
 
   .sidebar {
+    order: 1;
+  }
+
+  .shell-main {
     order: 2;
   }
 }


### PR DESCRIPTION
### Motivation
- Loaded `.cursor` rules `openapi.md` and `go.md` and adjusted responsive UI so the navigation block appears above content on narrow screens (`@media (max-width: 1180px)`).

### Description
- Updated `ui/src/style.css` to set `.sidebar` to `order: 1` and `.shell-main` to `order: 2` inside the `@media (max-width: 1180px)` breakpoint so the sidebar renders before the main content on mobile.

### Testing
- No automated tests were run for this style-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2927ad3948332b758ffbed74b67ee)