### PR TITLE
feat: show service realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ GitOps controller for Docker Swarm with an ArgoCD-inspired, but Swarm-native, co
 - Stack deployment only when a diff is detected (`compose + referenced configs/secrets` digest). .
 - GitOps reconciliation for Docker networks from `networks.file` with managed label `org.swarm-deploy.network.managed=true`.
 - UI and API are served by a single web server on `web.address`.
+- Service Realtime page with task snapshot (node hostname, state, created/updated timestamps, and task ID).
 - HTTP Basic authentication for UI and API via `web.security.authentication.basic.htpasswdFile`.
 - [Event History & Audit](./docs/event-history.md)
 - [Notification hooks for successful and failed deployments](./docs/notifications.md)

--- a/api/api-server.yaml
+++ b/api/api-server.yaml
@@ -162,6 +162,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceStatusResponse'
+
+  /api/v1/stacks/{stack}/services/{service}/realtime:
+    get:
+      operationId: getServiceRealtime
+      parameters:
+        - in: path
+          name: stack
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: service
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Service realtime tasks status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceRealtimeResponse'
   /api/v1/stacks/{stack}/services/{service}/deployments:
     get:
       operationId: listServiceDeployments
@@ -581,6 +603,27 @@ components:
           type: array
           items:
             type: string
+
+    ServiceRealtimeTask:
+      type: object
+      required: [id, node, current_state]
+      properties:
+        id:
+          type: string
+        node:
+          type: string
+        current_state:
+          type: string
+        error:
+          type: string
+    ServiceRealtimeResponse:
+      type: object
+      required: [tasks]
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceRealtimeTask'
     ServiceDeploymentStatus:
       type: string
       enum: [success, failed]

--- a/api/api-server.yaml
+++ b/api/api-server.yaml
@@ -612,6 +612,14 @@ components:
           type: string
         node:
           type: string
+        node_name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
         current_state:
           type: string
         error:

--- a/internal/entrypoints/webserver/generated/oas_client_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_client_gen.go
@@ -43,6 +43,10 @@ type Invoker interface {
 	//
 	// GET /api/v1/secrets/{name}
 	GetSecretByName(ctx context.Context, params GetSecretByNameParams) (*SecretDetailsResponse, error)
+	// GetServiceRealtime invokes getServiceRealtime operation.
+	//
+	// GET /api/v1/stacks/{stack}/services/{service}/realtime
+	GetServiceRealtime(ctx context.Context, params GetServiceRealtimeParams) (*ServiceRealtimeResponse, error)
 	// GetServiceStatus invokes getServiceStatus operation.
 	//
 	// GET /api/v1/stacks/{stack}/services/{service}/status
@@ -444,6 +448,116 @@ func (c *Client) sendGetSecretByName(ctx context.Context, params GetSecretByName
 
 	stage = "DecodeResponse"
 	result, err := decodeGetSecretByNameResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// GetServiceRealtime invokes getServiceRealtime operation.
+//
+// GET /api/v1/stacks/{stack}/services/{service}/realtime
+func (c *Client) GetServiceRealtime(ctx context.Context, params GetServiceRealtimeParams) (*ServiceRealtimeResponse, error) {
+	res, err := c.sendGetServiceRealtime(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendGetServiceRealtime(ctx context.Context, params GetServiceRealtimeParams) (res *ServiceRealtimeResponse, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getServiceRealtime"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.URLTemplateKey.String("/api/v1/stacks/{stack}/services/{service}/realtime"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, GetServiceRealtimeOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [5]string
+	pathParts[0] = "/api/v1/stacks/"
+	{
+		// Encode "stack" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "stack",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.Stack))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/services/"
+	{
+		// Encode "service" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "service",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.Service))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[3] = encoded
+	}
+	pathParts[4] = "/realtime"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeGetServiceRealtimeResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/entrypoints/webserver/generated/oas_handlers_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_handlers_gen.go
@@ -578,6 +578,151 @@ func (s *Server) handleGetSecretByNameRequest(args [1]string, argsEscaped bool, 
 	}
 }
 
+// handleGetServiceRealtimeRequest handles getServiceRealtime operation.
+//
+// GET /api/v1/stacks/{stack}/services/{service}/realtime
+func (s *Server) handleGetServiceRealtimeRequest(args [2]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getServiceRealtime"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/v1/stacks/{stack}/services/{service}/realtime"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), GetServiceRealtimeOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(codeAttr)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: GetServiceRealtimeOperation,
+			ID:   "getServiceRealtime",
+		}
+	)
+	params, err := decodeGetServiceRealtimeParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+
+	var response *ServiceRealtimeResponse
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    GetServiceRealtimeOperation,
+			OperationSummary: "",
+			OperationID:      "getServiceRealtime",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "stack",
+					In:   "path",
+				}: params.Stack,
+				{
+					Name: "service",
+					In:   "path",
+				}: params.Service,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = GetServiceRealtimeParams
+			Response = *ServiceRealtimeResponse
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackGetServiceRealtimeParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetServiceRealtime(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetServiceRealtime(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeGetServiceRealtimeResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleGetServiceStatusRequest handles getServiceStatus operation.
 //
 // GET /api/v1/stacks/{stack}/services/{service}/status

--- a/internal/entrypoints/webserver/generated/oas_json_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_json_gen.go
@@ -4091,6 +4091,24 @@ func (s *ServiceRealtimeTask) encodeFields(e *jx.Encoder) {
 		e.Str(s.Node)
 	}
 	{
+		if s.NodeName.Set {
+			e.FieldStart("node_name")
+			s.NodeName.Encode(e)
+		}
+	}
+	{
+		if s.CreatedAt.Set {
+			e.FieldStart("created_at")
+			s.CreatedAt.Encode(e, json.EncodeDateTime)
+		}
+	}
+	{
+		if s.UpdatedAt.Set {
+			e.FieldStart("updated_at")
+			s.UpdatedAt.Encode(e, json.EncodeDateTime)
+		}
+	}
+	{
 		e.FieldStart("current_state")
 		e.Str(s.CurrentState)
 	}
@@ -4102,11 +4120,14 @@ func (s *ServiceRealtimeTask) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfServiceRealtimeTask = [4]string{
+var jsonFieldsNameOfServiceRealtimeTask = [7]string{
 	0: "id",
 	1: "node",
-	2: "current_state",
-	3: "error",
+	2: "node_name",
+	3: "created_at",
+	4: "updated_at",
+	5: "current_state",
+	6: "error",
 }
 
 // Decode decodes ServiceRealtimeTask from json.
@@ -4142,8 +4163,38 @@ func (s *ServiceRealtimeTask) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"node\"")
 			}
+		case "node_name":
+			if err := func() error {
+				s.NodeName.Reset()
+				if err := s.NodeName.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node_name\"")
+			}
+		case "created_at":
+			if err := func() error {
+				s.CreatedAt.Reset()
+				if err := s.CreatedAt.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"created_at\"")
+			}
+		case "updated_at":
+			if err := func() error {
+				s.UpdatedAt.Reset()
+				if err := s.UpdatedAt.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"updated_at\"")
+			}
 		case "current_state":
-			requiredBitSet[0] |= 1 << 2
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.CurrentState = string(v)
@@ -4174,7 +4225,7 @@ func (s *ServiceRealtimeTask) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000111,
+		0b00100011,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/internal/entrypoints/webserver/generated/oas_json_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_json_gen.go
@@ -3968,6 +3968,259 @@ func (s *ServiceInfoType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *ServiceRealtimeResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ServiceRealtimeResponse) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("tasks")
+		e.ArrStart()
+		for _, elem := range s.Tasks {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
+	}
+}
+
+var jsonFieldsNameOfServiceRealtimeResponse = [1]string{
+	0: "tasks",
+}
+
+// Decode decodes ServiceRealtimeResponse from json.
+func (s *ServiceRealtimeResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ServiceRealtimeResponse to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "tasks":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				s.Tasks = make([]ServiceRealtimeTask, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem ServiceRealtimeTask
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Tasks = append(s.Tasks, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tasks\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ServiceRealtimeResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfServiceRealtimeResponse) {
+					name = jsonFieldsNameOfServiceRealtimeResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ServiceRealtimeResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ServiceRealtimeResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ServiceRealtimeTask) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ServiceRealtimeTask) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("id")
+		e.Str(s.ID)
+	}
+	{
+		e.FieldStart("node")
+		e.Str(s.Node)
+	}
+	{
+		e.FieldStart("current_state")
+		e.Str(s.CurrentState)
+	}
+	{
+		if s.Error.Set {
+			e.FieldStart("error")
+			s.Error.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfServiceRealtimeTask = [4]string{
+	0: "id",
+	1: "node",
+	2: "current_state",
+	3: "error",
+}
+
+// Decode decodes ServiceRealtimeTask from json.
+func (s *ServiceRealtimeTask) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ServiceRealtimeTask to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "id":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.ID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"id\"")
+			}
+		case "node":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Node = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node\"")
+			}
+		case "current_state":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.CurrentState = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"current_state\"")
+			}
+		case "error":
+			if err := func() error {
+				s.Error.Reset()
+				if err := s.Error.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"error\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ServiceRealtimeTask")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfServiceRealtimeTask) {
+					name = jsonFieldsNameOfServiceRealtimeTask[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ServiceRealtimeTask) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ServiceRealtimeTask) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s ServiceSpecLabelGroupResponse) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)

--- a/internal/entrypoints/webserver/generated/oas_operations_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_operations_gen.go
@@ -10,6 +10,7 @@ const (
 	GetCurrentUserOperation         OperationName = "GetCurrentUser"
 	GetGitCommitOperation           OperationName = "GetGitCommit"
 	GetSecretByNameOperation        OperationName = "GetSecretByName"
+	GetServiceRealtimeOperation     OperationName = "GetServiceRealtime"
 	GetServiceStatusOperation       OperationName = "GetServiceStatus"
 	ListEventsOperation             OperationName = "ListEvents"
 	ListNetworksOperation           OperationName = "ListNetworks"

--- a/internal/entrypoints/webserver/generated/oas_parameters_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_parameters_gen.go
@@ -145,6 +145,124 @@ func decodeGetSecretByNameParams(args [1]string, argsEscaped bool, r *http.Reque
 	return params, nil
 }
 
+// GetServiceRealtimeParams is parameters of getServiceRealtime operation.
+type GetServiceRealtimeParams struct {
+	Stack   string
+	Service string
+}
+
+func unpackGetServiceRealtimeParams(packed middleware.Parameters) (params GetServiceRealtimeParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "stack",
+			In:   "path",
+		}
+		params.Stack = packed[key].(string)
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "service",
+			In:   "path",
+		}
+		params.Service = packed[key].(string)
+	}
+	return params
+}
+
+func decodeGetServiceRealtimeParams(args [2]string, argsEscaped bool, r *http.Request) (params GetServiceRealtimeParams, _ error) {
+	// Decode path: stack.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "stack",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.Stack = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "stack",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	// Decode path: service.
+	if err := func() error {
+		param := args[1]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[1])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "service",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.Service = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "service",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // GetServiceStatusParams is parameters of getServiceStatus operation.
 type GetServiceStatusParams struct {
 	Stack   string

--- a/internal/entrypoints/webserver/generated/oas_response_decoders_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_response_decoders_gen.go
@@ -204,6 +204,56 @@ func decodeGetSecretByNameResponse(resp *http.Response) (res *SecretDetailsRespo
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
+func decodeGetServiceRealtimeResponse(resp *http.Response) (res *ServiceRealtimeResponse, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ServiceRealtimeResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodeGetServiceStatusResponse(resp *http.Response) (res *ServiceStatusResponse, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/entrypoints/webserver/generated/oas_response_encoders_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_response_encoders_gen.go
@@ -67,6 +67,20 @@ func encodeGetSecretByNameResponse(response *SecretDetailsResponse, w http.Respo
 	return nil
 }
 
+func encodeGetServiceRealtimeResponse(response *ServiceRealtimeResponse, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := new(jx.Encoder)
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
 func encodeGetServiceStatusResponse(response *ServiceStatusResponse, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(200)

--- a/internal/entrypoints/webserver/generated/oas_router_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_router_gen.go
@@ -461,6 +461,34 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										return
 									}
 
+								case 'r': // Prefix: "realtime"
+
+									if l := len("realtime"); len(elem) >= l && elem[0:l] == "realtime" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										// Leaf node.
+										switch r.Method {
+										case "GET":
+											s.handleGetServiceRealtimeRequest([2]string{
+												args[0],
+												args[1],
+											}, elemIsEscaped, w, r)
+										default:
+											s.notAllowed(w, r, notAllowedParams{
+												allowedMethods: "GET",
+												allowedHeaders: nil,
+												acceptPost:     "",
+												acceptPatch:    "",
+											})
+										}
+
+										return
+									}
+
 								case 's': // Prefix: "status"
 
 									if l := len("status"); len(elem) >= l && elem[0:l] == "status" {
@@ -1028,6 +1056,31 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 											r.operationID = "listServiceDeployments"
 											r.operationGroup = ""
 											r.pathPattern = "/api/v1/stacks/{stack}/services/{service}/deployments"
+											r.args = args
+											r.count = 2
+											return r, true
+										default:
+											return
+										}
+									}
+
+								case 'r': // Prefix: "realtime"
+
+									if l := len("realtime"); len(elem) >= l && elem[0:l] == "realtime" {
+										elem = elem[l:]
+									} else {
+										break
+									}
+
+									if len(elem) == 0 {
+										// Leaf node.
+										switch method {
+										case "GET":
+											r.name = GetServiceRealtimeOperation
+											r.summary = ""
+											r.operationID = "getServiceRealtime"
+											r.operationGroup = ""
+											r.pathPattern = "/api/v1/stacks/{stack}/services/{service}/realtime"
 											r.args = args
 											r.count = 2
 											return r, true

--- a/internal/entrypoints/webserver/generated/oas_schemas_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_schemas_gen.go
@@ -1931,6 +1931,69 @@ func (s *ServiceInfoType) UnmarshalText(data []byte) error {
 	}
 }
 
+// Ref: #/components/schemas/ServiceRealtimeResponse
+type ServiceRealtimeResponse struct {
+	Tasks []ServiceRealtimeTask `json:"tasks"`
+}
+
+// GetTasks returns the value of Tasks.
+func (s *ServiceRealtimeResponse) GetTasks() []ServiceRealtimeTask {
+	return s.Tasks
+}
+
+// SetTasks sets the value of Tasks.
+func (s *ServiceRealtimeResponse) SetTasks(val []ServiceRealtimeTask) {
+	s.Tasks = val
+}
+
+// Ref: #/components/schemas/ServiceRealtimeTask
+type ServiceRealtimeTask struct {
+	ID           string    `json:"id"`
+	Node         string    `json:"node"`
+	CurrentState string    `json:"current_state"`
+	Error        OptString `json:"error"`
+}
+
+// GetID returns the value of ID.
+func (s *ServiceRealtimeTask) GetID() string {
+	return s.ID
+}
+
+// GetNode returns the value of Node.
+func (s *ServiceRealtimeTask) GetNode() string {
+	return s.Node
+}
+
+// GetCurrentState returns the value of CurrentState.
+func (s *ServiceRealtimeTask) GetCurrentState() string {
+	return s.CurrentState
+}
+
+// GetError returns the value of Error.
+func (s *ServiceRealtimeTask) GetError() OptString {
+	return s.Error
+}
+
+// SetID sets the value of ID.
+func (s *ServiceRealtimeTask) SetID(val string) {
+	s.ID = val
+}
+
+// SetNode sets the value of Node.
+func (s *ServiceRealtimeTask) SetNode(val string) {
+	s.Node = val
+}
+
+// SetCurrentState sets the value of CurrentState.
+func (s *ServiceRealtimeTask) SetCurrentState(val string) {
+	s.CurrentState = val
+}
+
+// SetError sets the value of Error.
+func (s *ServiceRealtimeTask) SetError(val OptString) {
+	s.Error = val
+}
+
 // Ref: #/components/schemas/ServiceSpecLabelGroupResponse
 type ServiceSpecLabelGroupResponse map[string]string
 

--- a/internal/entrypoints/webserver/generated/oas_schemas_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_schemas_gen.go
@@ -1948,10 +1948,13 @@ func (s *ServiceRealtimeResponse) SetTasks(val []ServiceRealtimeTask) {
 
 // Ref: #/components/schemas/ServiceRealtimeTask
 type ServiceRealtimeTask struct {
-	ID           string    `json:"id"`
-	Node         string    `json:"node"`
-	CurrentState string    `json:"current_state"`
-	Error        OptString `json:"error"`
+	ID           string      `json:"id"`
+	Node         string      `json:"node"`
+	NodeName     OptString   `json:"node_name"`
+	CreatedAt    OptDateTime `json:"created_at"`
+	UpdatedAt    OptDateTime `json:"updated_at"`
+	CurrentState string      `json:"current_state"`
+	Error        OptString   `json:"error"`
 }
 
 // GetID returns the value of ID.
@@ -1962,6 +1965,21 @@ func (s *ServiceRealtimeTask) GetID() string {
 // GetNode returns the value of Node.
 func (s *ServiceRealtimeTask) GetNode() string {
 	return s.Node
+}
+
+// GetNodeName returns the value of NodeName.
+func (s *ServiceRealtimeTask) GetNodeName() OptString {
+	return s.NodeName
+}
+
+// GetCreatedAt returns the value of CreatedAt.
+func (s *ServiceRealtimeTask) GetCreatedAt() OptDateTime {
+	return s.CreatedAt
+}
+
+// GetUpdatedAt returns the value of UpdatedAt.
+func (s *ServiceRealtimeTask) GetUpdatedAt() OptDateTime {
+	return s.UpdatedAt
 }
 
 // GetCurrentState returns the value of CurrentState.
@@ -1982,6 +2000,21 @@ func (s *ServiceRealtimeTask) SetID(val string) {
 // SetNode sets the value of Node.
 func (s *ServiceRealtimeTask) SetNode(val string) {
 	s.Node = val
+}
+
+// SetNodeName sets the value of NodeName.
+func (s *ServiceRealtimeTask) SetNodeName(val OptString) {
+	s.NodeName = val
+}
+
+// SetCreatedAt sets the value of CreatedAt.
+func (s *ServiceRealtimeTask) SetCreatedAt(val OptDateTime) {
+	s.CreatedAt = val
+}
+
+// SetUpdatedAt sets the value of UpdatedAt.
+func (s *ServiceRealtimeTask) SetUpdatedAt(val OptDateTime) {
+	s.UpdatedAt = val
 }
 
 // SetCurrentState sets the value of CurrentState.

--- a/internal/entrypoints/webserver/generated/oas_server_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_server_gen.go
@@ -24,6 +24,10 @@ type Handler interface {
 	//
 	// GET /api/v1/secrets/{name}
 	GetSecretByName(ctx context.Context, params GetSecretByNameParams) (*SecretDetailsResponse, error)
+	// GetServiceRealtime implements getServiceRealtime operation.
+	//
+	// GET /api/v1/stacks/{stack}/services/{service}/realtime
+	GetServiceRealtime(ctx context.Context, params GetServiceRealtimeParams) (*ServiceRealtimeResponse, error)
 	// GetServiceStatus implements getServiceStatus operation.
 	//
 	// GET /api/v1/stacks/{stack}/services/{service}/status

--- a/internal/entrypoints/webserver/generated/oas_unimplemented_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_unimplemented_gen.go
@@ -41,6 +41,13 @@ func (UnimplementedHandler) GetSecretByName(ctx context.Context, params GetSecre
 	return r, ht.ErrNotImplemented
 }
 
+// GetServiceRealtime implements getServiceRealtime operation.
+//
+// GET /api/v1/stacks/{stack}/services/{service}/realtime
+func (UnimplementedHandler) GetServiceRealtime(ctx context.Context, params GetServiceRealtimeParams) (r *ServiceRealtimeResponse, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // GetServiceStatus implements getServiceStatus operation.
 //
 // GET /api/v1/stacks/{stack}/services/{service}/status

--- a/internal/entrypoints/webserver/generated/oas_validators_gen.go
+++ b/internal/entrypoints/webserver/generated/oas_validators_gen.go
@@ -679,6 +679,29 @@ func (s ServiceInfoType) Validate() error {
 	}
 }
 
+func (s *ServiceRealtimeResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if s.Tasks == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "tasks",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *ServiceSpecResponse) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer

--- a/internal/entrypoints/webserver/handlers/get_service_realtime.go
+++ b/internal/entrypoints/webserver/handlers/get_service_realtime.go
@@ -17,7 +17,12 @@ func (h *handler) GetServiceRealtime(
 ) (*generated.ServiceRealtimeResponse, error) {
 	tasks, err := h.serviceInspector.ListTasks(ctx, swarm.NewServiceReference(params.Stack, params.Service))
 	if err == nil {
-		return &generated.ServiceRealtimeResponse{Tasks: toGeneratedServiceRealtimeTasks(tasks)}, nil
+		nodes := h.nodes.List()
+		nodeHostnamesByID := toNodeHostnameMap(nodes)
+
+		return &generated.ServiceRealtimeResponse{
+			Tasks: toGeneratedServiceRealtimeTasks(tasks, nodeHostnamesByID),
+		}, nil
 	}
 
 	if errors.Is(err, swarm.ErrServiceNotFound) {

--- a/internal/entrypoints/webserver/handlers/get_service_realtime.go
+++ b/internal/entrypoints/webserver/handlers/get_service_realtime.go
@@ -17,11 +17,9 @@ func (h *handler) GetServiceRealtime(
 ) (*generated.ServiceRealtimeResponse, error) {
 	tasks, err := h.serviceInspector.ListTasks(ctx, swarm.NewServiceReference(params.Stack, params.Service))
 	if err == nil {
-		nodes := h.nodes.List()
-		nodeHostnamesByID := toNodeHostnameMap(nodes)
 
 		return &generated.ServiceRealtimeResponse{
-			Tasks: toGeneratedServiceRealtimeTasks(tasks, nodeHostnamesByID),
+			Tasks: toGeneratedServiceRealtimeTasks(tasks, h.nodes.Map()),
 		}, nil
 	}
 

--- a/internal/entrypoints/webserver/handlers/get_service_realtime.go
+++ b/internal/entrypoints/webserver/handlers/get_service_realtime.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	generated "github.com/swarm-deploy/swarm-deploy/internal/entrypoints/webserver/generated"
+	"github.com/swarm-deploy/swarm-deploy/internal/swarm"
+)
+
+func (h *handler) GetServiceRealtime(
+	ctx context.Context,
+	params generated.GetServiceRealtimeParams,
+) (*generated.ServiceRealtimeResponse, error) {
+	tasks, err := h.serviceInspector.Realtime(ctx, swarm.NewServiceReference(params.Stack, params.Service))
+	if err == nil {
+		return &generated.ServiceRealtimeResponse{Tasks: toGeneratedServiceRealtimeTasks(tasks)}, nil
+	}
+
+	if errors.Is(err, swarm.ErrServiceNotFound) {
+		return nil, withStatusError(
+			http.StatusNotFound,
+			fmt.Errorf("service %s/%s not found", params.Stack, params.Service),
+		)
+	}
+
+	slog.ErrorContext(
+		ctx,
+		"[webserver] failed to read service realtime",
+		slog.String("stack", params.Stack),
+		slog.String("service", params.Service),
+		slog.Any("err", err),
+	)
+	return nil, withStatusError(http.StatusInternalServerError, errors.New("unable to get service realtime"))
+}

--- a/internal/entrypoints/webserver/handlers/get_service_realtime.go
+++ b/internal/entrypoints/webserver/handlers/get_service_realtime.go
@@ -15,7 +15,7 @@ func (h *handler) GetServiceRealtime(
 	ctx context.Context,
 	params generated.GetServiceRealtimeParams,
 ) (*generated.ServiceRealtimeResponse, error) {
-	tasks, err := h.serviceInspector.Realtime(ctx, swarm.NewServiceReference(params.Stack, params.Service))
+	tasks, err := h.serviceInspector.ListTasks(ctx, swarm.NewServiceReference(params.Stack, params.Service))
 	if err == nil {
 		return &generated.ServiceRealtimeResponse{Tasks: toGeneratedServiceRealtimeTasks(tasks)}, nil
 	}

--- a/internal/entrypoints/webserver/handlers/get_service_realtime_test.go
+++ b/internal/entrypoints/webserver/handlers/get_service_realtime_test.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	generated "github.com/swarm-deploy/swarm-deploy/internal/entrypoints/webserver/generated"
+	swarmnode "github.com/swarm-deploy/swarm-deploy/internal/node"
+	"github.com/swarm-deploy/swarm-deploy/internal/swarm"
+)
+
+func TestHandlerGetServiceRealtime_MapsNodeHostname(t *testing.T) {
+	t.Parallel()
+
+	nodeStore, err := swarmnode.NewNodeStore(filepath.Join(t.TempDir(), "nodes.json"))
+	require.NoError(t, err)
+	require.NoError(t, nodeStore.Replace([]swarm.Node{
+		{
+			ID:       "node-1",
+			Hostname: "worker-1",
+		},
+	}))
+
+	h := &handler{
+		serviceInspector: fakeServiceStatusInspector{
+			tasks: []swarm.ServiceTask{
+				{
+					ID:           "task-1",
+					Node:         "node-1",
+					CreatedAt:    time.Date(2026, time.May, 29, 9, 0, 0, 0, time.UTC),
+					UpdatedAt:    time.Date(2026, time.May, 29, 9, 1, 0, 0, time.UTC),
+					CurrentState: "running",
+				},
+			},
+		},
+		nodes: nodeStore,
+	}
+
+	resp, err := h.GetServiceRealtime(context.Background(), generated.GetServiceRealtimeParams{
+		Stack:   "payments",
+		Service: "api",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Tasks, 1)
+
+	nodeName, ok := resp.Tasks[0].NodeName.Get()
+	require.True(t, ok)
+	assert.Equal(t, "worker-1", nodeName)
+	assert.Equal(t, "node-1", resp.Tasks[0].Node)
+	createdAt, ok := resp.Tasks[0].CreatedAt.Get()
+	require.True(t, ok)
+	assert.Equal(t, time.Date(2026, time.May, 29, 9, 0, 0, 0, time.UTC), createdAt)
+	updatedAt, ok := resp.Tasks[0].UpdatedAt.Get()
+	require.True(t, ok)
+	assert.Equal(t, time.Date(2026, time.May, 29, 9, 1, 0, 0, time.UTC), updatedAt)
+}
+
+func TestHandlerGetServiceRealtime_LeavesNodeNameEmptyIfNodeIsUnknown(t *testing.T) {
+	t.Parallel()
+
+	nodeStore, err := swarmnode.NewNodeStore(filepath.Join(t.TempDir(), "nodes.json"))
+	require.NoError(t, err)
+	require.NoError(t, nodeStore.Replace([]swarm.Node{
+		{
+			ID:       "node-2",
+			Hostname: "worker-2",
+		},
+	}))
+
+	h := &handler{
+		serviceInspector: fakeServiceStatusInspector{
+			tasks: []swarm.ServiceTask{
+				{
+					ID:           "task-1",
+					Node:         "node-1",
+					CurrentState: "running",
+				},
+			},
+		},
+		nodes: nodeStore,
+	}
+
+	resp, err := h.GetServiceRealtime(context.Background(), generated.GetServiceRealtimeParams{
+		Stack:   "payments",
+		Service: "api",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Tasks, 1)
+
+	_, ok := resp.Tasks[0].NodeName.Get()
+	assert.False(t, ok)
+	assert.Equal(t, "node-1", resp.Tasks[0].Node)
+}
+
+func TestHandlerGetServiceRealtime_NotFound(t *testing.T) {
+	t.Parallel()
+
+	h := &handler{
+		serviceInspector: fakeServiceStatusInspector{
+			err: swarm.ErrServiceNotFound,
+		},
+	}
+
+	_, err := h.GetServiceRealtime(context.Background(), generated.GetServiceRealtimeParams{
+		Stack:   "payments",
+		Service: "api",
+	})
+	require.Error(t, err)
+
+	var statusErr *statusError
+	require.True(t, errors.As(err, &statusErr))
+	assert.Equal(t, 404, statusErr.code)
+}

--- a/internal/entrypoints/webserver/handlers/get_service_status_test.go
+++ b/internal/entrypoints/webserver/handlers/get_service_status_test.go
@@ -16,6 +16,7 @@ import (
 
 type fakeServiceStatusInspector struct {
 	status swarm.ServiceStatus
+	tasks  []swarm.ServiceTask
 	err    error
 }
 
@@ -32,7 +33,7 @@ func (f fakeServiceStatusInspector) ListTasks(context.Context, swarm.ServiceRefe
 		return nil, f.err
 	}
 
-	return nil, nil
+	return f.tasks, nil
 }
 
 func TestHandlerGetServiceStatus(t *testing.T) {

--- a/internal/entrypoints/webserver/handlers/get_service_status_test.go
+++ b/internal/entrypoints/webserver/handlers/get_service_status_test.go
@@ -27,7 +27,7 @@ func (f fakeServiceStatusInspector) GetStatus(context.Context, swarm.ServiceRefe
 	return f.status, nil
 }
 
-func (f fakeServiceStatusInspector) Realtime(context.Context, swarm.ServiceReference) ([]swarm.ServiceTaskRealtime, error) {
+func (f fakeServiceStatusInspector) ListTasks(context.Context, swarm.ServiceReference) ([]swarm.ServiceTask, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/internal/entrypoints/webserver/handlers/get_service_status_test.go
+++ b/internal/entrypoints/webserver/handlers/get_service_status_test.go
@@ -27,6 +27,14 @@ func (f fakeServiceStatusInspector) GetStatus(context.Context, swarm.ServiceRefe
 	return f.status, nil
 }
 
+func (f fakeServiceStatusInspector) Realtime(context.Context, swarm.ServiceReference) ([]swarm.ServiceTaskRealtime, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return nil, nil
+}
+
 func TestHandlerGetServiceStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/entrypoints/webserver/handlers/handler.go
+++ b/internal/entrypoints/webserver/handlers/handler.go
@@ -17,7 +17,7 @@ import (
 type ServiceStatusInspector interface {
 	// InspectServiceStatus returns compact status snapshot for a stack service.
 	GetStatus(ctx context.Context, serviceRef swarm.ServiceReference) (swarm.ServiceStatus, error)
-	// Realtime returns service tasks for realtime container status rendering.
+	// ListTasks returns service tasks for realtime container status rendering.
 	ListTasks(ctx context.Context, serviceRef swarm.ServiceReference) ([]swarm.ServiceTask, error)
 }
 

--- a/internal/entrypoints/webserver/handlers/handler.go
+++ b/internal/entrypoints/webserver/handlers/handler.go
@@ -18,7 +18,7 @@ type ServiceStatusInspector interface {
 	// InspectServiceStatus returns compact status snapshot for a stack service.
 	GetStatus(ctx context.Context, serviceRef swarm.ServiceReference) (swarm.ServiceStatus, error)
 	// Realtime returns service tasks for realtime container status rendering.
-	Realtime(ctx context.Context, serviceRef swarm.ServiceReference) ([]swarm.ServiceTaskRealtime, error)
+	ListTasks(ctx context.Context, serviceRef swarm.ServiceReference) ([]swarm.ServiceTask, error)
 }
 
 // SecretsReader reads current Docker secrets snapshot.

--- a/internal/entrypoints/webserver/handlers/handler.go
+++ b/internal/entrypoints/webserver/handlers/handler.go
@@ -17,6 +17,8 @@ import (
 type ServiceStatusInspector interface {
 	// InspectServiceStatus returns compact status snapshot for a stack service.
 	GetStatus(ctx context.Context, serviceRef swarm.ServiceReference) (swarm.ServiceStatus, error)
+	// Realtime returns service tasks for realtime container status rendering.
+	Realtime(ctx context.Context, serviceRef swarm.ServiceReference) ([]swarm.ServiceTaskRealtime, error)
 }
 
 // SecretsReader reads current Docker secrets snapshot.

--- a/internal/entrypoints/webserver/handlers/mappers.go
+++ b/internal/entrypoints/webserver/handlers/mappers.go
@@ -74,6 +74,23 @@ func toGeneratedServiceStatus(status swarm.ServiceStatus) *generated.ServiceStat
 	return resp
 }
 
+func toGeneratedServiceRealtimeTasks(tasks []swarm.ServiceTaskRealtime) []generated.ServiceRealtimeTask {
+	mapped := make([]generated.ServiceRealtimeTask, 0, len(tasks))
+	for _, task := range tasks {
+		item := generated.ServiceRealtimeTask{
+			ID:           task.ID,
+			Node:         task.Node,
+			CurrentState: task.CurrentState,
+		}
+		if task.Error != "" {
+			item.Error = generated.NewOptString(task.Error)
+		}
+		mapped = append(mapped, item)
+	}
+
+	return mapped
+}
+
 func toGeneratedServiceDeployments(
 	entries []history.Entry,
 	stackName string,

--- a/internal/entrypoints/webserver/handlers/mappers.go
+++ b/internal/entrypoints/webserver/handlers/mappers.go
@@ -74,13 +74,25 @@ func toGeneratedServiceStatus(status swarm.ServiceStatus) *generated.ServiceStat
 	return resp
 }
 
-func toGeneratedServiceRealtimeTasks(tasks []swarm.ServiceTask) []generated.ServiceRealtimeTask {
+func toGeneratedServiceRealtimeTasks(
+	tasks []swarm.ServiceTask,
+	nodeHostnamesByID map[string]string,
+) []generated.ServiceRealtimeTask {
 	mapped := make([]generated.ServiceRealtimeTask, 0, len(tasks))
 	for _, task := range tasks {
 		item := generated.ServiceRealtimeTask{
 			ID:           task.ID,
 			Node:         task.Node,
 			CurrentState: task.CurrentState,
+		}
+		if !task.CreatedAt.IsZero() {
+			item.CreatedAt = generated.NewOptDateTime(task.CreatedAt)
+		}
+		if !task.UpdatedAt.IsZero() {
+			item.UpdatedAt = generated.NewOptDateTime(task.UpdatedAt)
+		}
+		if nodeName := nodeHostnamesByID[task.Node]; nodeName != "" {
+			item.NodeName = generated.NewOptString(nodeName)
 		}
 		if task.Error != "" {
 			item.Error = generated.NewOptString(task.Error)
@@ -89,6 +101,23 @@ func toGeneratedServiceRealtimeTasks(tasks []swarm.ServiceTask) []generated.Serv
 	}
 
 	return mapped
+}
+
+func toNodeHostnameMap(nodes []swarm.Node) map[string]string {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	nodeHostnamesByID := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		if node.ID == "" || node.Hostname == "" {
+			continue
+		}
+
+		nodeHostnamesByID[node.ID] = node.Hostname
+	}
+
+	return nodeHostnamesByID
 }
 
 func toGeneratedServiceDeployments(

--- a/internal/entrypoints/webserver/handlers/mappers.go
+++ b/internal/entrypoints/webserver/handlers/mappers.go
@@ -74,7 +74,7 @@ func toGeneratedServiceStatus(status swarm.ServiceStatus) *generated.ServiceStat
 	return resp
 }
 
-func toGeneratedServiceRealtimeTasks(tasks []swarm.ServiceTaskRealtime) []generated.ServiceRealtimeTask {
+func toGeneratedServiceRealtimeTasks(tasks []swarm.ServiceTask) []generated.ServiceRealtimeTask {
 	mapped := make([]generated.ServiceRealtimeTask, 0, len(tasks))
 	for _, task := range tasks {
 		item := generated.ServiceRealtimeTask{

--- a/internal/entrypoints/webserver/handlers/mappers.go
+++ b/internal/entrypoints/webserver/handlers/mappers.go
@@ -76,7 +76,7 @@ func toGeneratedServiceStatus(status swarm.ServiceStatus) *generated.ServiceStat
 
 func toGeneratedServiceRealtimeTasks(
 	tasks []swarm.ServiceTask,
-	nodeHostnamesByID map[string]string,
+	nodeMap map[string]swarm.Node,
 ) []generated.ServiceRealtimeTask {
 	mapped := make([]generated.ServiceRealtimeTask, 0, len(tasks))
 	for _, task := range tasks {
@@ -91,8 +91,8 @@ func toGeneratedServiceRealtimeTasks(
 		if !task.UpdatedAt.IsZero() {
 			item.UpdatedAt = generated.NewOptDateTime(task.UpdatedAt)
 		}
-		if nodeName := nodeHostnamesByID[task.Node]; nodeName != "" {
-			item.NodeName = generated.NewOptString(nodeName)
+		if node, nodeExists := nodeMap[task.Node]; nodeExists {
+			item.NodeName = generated.NewOptString(node.Hostname)
 		}
 		if task.Error != "" {
 			item.Error = generated.NewOptString(task.Error)
@@ -101,23 +101,6 @@ func toGeneratedServiceRealtimeTasks(
 	}
 
 	return mapped
-}
-
-func toNodeHostnameMap(nodes []swarm.Node) map[string]string {
-	if len(nodes) == 0 {
-		return nil
-	}
-
-	nodeHostnamesByID := make(map[string]string, len(nodes))
-	for _, node := range nodes {
-		if node.ID == "" || node.Hostname == "" {
-			continue
-		}
-
-		nodeHostnamesByID[node.ID] = node.Hostname
-	}
-
-	return nodeHostnamesByID
 }
 
 func toGeneratedServiceDeployments(

--- a/internal/node/store.go
+++ b/internal/node/store.go
@@ -16,9 +16,10 @@ const storeFileModePrivate = 0o600
 
 // Store persists nodes snapshot in a JSON file.
 type Store struct {
-	mu   sync.RWMutex
-	path string
-	rows []swarm.Node
+	mu      sync.RWMutex
+	path    string
+	rows    []swarm.Node
+	nodeMap map[string]swarm.Node
 }
 
 // NewNodeStore creates nodes store and loads saved rows from disk.
@@ -34,6 +35,14 @@ func NewNodeStore(path string) (*Store, error) {
 	return s, nil
 }
 
+// Map returns map<node.id>swarm.Node.
+func (s *Store) Map() map[string]swarm.Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.nodeMap
+}
+
 // List returns a copy of all saved nodes.
 func (s *Store) List() []swarm.Node {
 	s.mu.RLock()
@@ -47,8 +56,7 @@ func (s *Store) Replace(nodes []swarm.Node) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.rows = cloneNodes(nodes)
-	sortNodes(s.rows)
+	s.setNodes(nodes)
 
 	return s.flushLocked()
 }
@@ -75,9 +83,7 @@ func (s *Store) load() error {
 		return fmt.Errorf("decode nodes file: %w", unmarshalErr)
 	}
 
-	s.rows = rows
-
-	sortNodes(s.rows)
+	s.setNodes(rows)
 	return nil
 }
 
@@ -96,6 +102,20 @@ func (s *Store) flushLocked() error {
 	}
 
 	return nil
+}
+
+func (s *Store) setNodes(rows []swarm.Node) {
+	s.nodeMap = make(map[string]swarm.Node, len(s.rows))
+	s.rows = make([]swarm.Node, len(rows))
+
+	for i, row := range rows {
+		node := cloneNode(row)
+
+		s.rows[i] = node
+		s.nodeMap[row.ID] = node
+	}
+
+	sortNodes(s.rows)
 }
 
 func sortNodes(nodes []swarm.Node) {

--- a/internal/swarm/service.go
+++ b/internal/swarm/service.go
@@ -25,6 +25,10 @@ type ServiceTask struct {
 	ID string
 	// Node is a task node identifier.
 	Node string
+	// CreatedAt is task creation timestamp from Docker Swarm.
+	CreatedAt time.Time
+	// UpdatedAt is task last update timestamp from Docker Swarm.
+	UpdatedAt time.Time
 	// CurrentState is a current task state in docker status format.
 	CurrentState string
 	// Error is a task runtime error.

--- a/internal/swarm/service.go
+++ b/internal/swarm/service.go
@@ -19,8 +19,8 @@ type ServiceStatus struct {
 	Spec ServiceSpec
 }
 
-// ServiceTaskRealtime contains compact realtime task data for service container status.
-type ServiceTaskRealtime struct {
+// ServiceTask contains compact realtime task data for service container status.
+type ServiceTask struct {
 	// ID is a Docker task identifier.
 	ID string
 	// Node is a task node identifier.

--- a/internal/swarm/service.go
+++ b/internal/swarm/service.go
@@ -19,6 +19,18 @@ type ServiceStatus struct {
 	Spec ServiceSpec
 }
 
+// ServiceTaskRealtime contains compact realtime task data for service container status.
+type ServiceTaskRealtime struct {
+	// ID is a Docker task identifier.
+	ID string
+	// Node is a task node identifier.
+	Node string
+	// CurrentState is a current task state in docker status format.
+	CurrentState string
+	// Error is a task runtime error.
+	Error string
+}
+
 // ServiceSpec is a compact service spec projection.
 type ServiceSpec struct {
 	// Image is a full image reference configured for the service.

--- a/internal/swarm/service_manager.go
+++ b/internal/swarm/service_manager.go
@@ -15,9 +15,9 @@ import (
 	"github.com/avast/retry-go/v5"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	dockerswarm "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/api/types/filters"
 )
 
 const (

--- a/internal/swarm/service_manager.go
+++ b/internal/swarm/service_manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	dockerswarm "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/types/filters"
 )
 
 const (
@@ -124,6 +125,34 @@ func (m *ServiceManager) GetStatus(ctx context.Context, serviceRef ServiceRefere
 		Service: serviceRef.ServiceName(),
 		Spec:    toServiceSpec(service.Spec),
 	}, nil
+}
+
+// Realtime returns service tasks for realtime container status rendering.
+func (m *ServiceManager) Realtime(ctx context.Context, serviceRef ServiceReference) ([]ServiceTaskRealtime, error) {
+	fullServiceName := serviceRef.Name()
+
+	tasks, err := m.dockerClient.TaskList(ctx, dockerswarm.TaskListOptions{
+		Filters: filters.NewArgs(filters.Arg("service", fullServiceName)),
+	})
+	if err != nil {
+		if isNotFoundErr(err) {
+			return nil, ErrServiceNotFound
+		}
+
+		return nil, fmt.Errorf("list tasks for service %s: %w", fullServiceName, err)
+	}
+
+	out := make([]ServiceTaskRealtime, 0, len(tasks))
+	for _, task := range tasks {
+		out = append(out, ServiceTaskRealtime{
+			ID:           task.ID,
+			Node:         task.NodeID,
+			CurrentState: string(task.Status.State),
+			Error:        task.Status.Err,
+		})
+	}
+
+	return out, nil
 }
 
 // Get returns full compact service projection for a stack service.

--- a/internal/swarm/service_manager.go
+++ b/internal/swarm/service_manager.go
@@ -127,8 +127,8 @@ func (m *ServiceManager) GetStatus(ctx context.Context, serviceRef ServiceRefere
 	}, nil
 }
 
-// Realtime returns service tasks for realtime container status rendering.
-func (m *ServiceManager) Realtime(ctx context.Context, serviceRef ServiceReference) ([]ServiceTaskRealtime, error) {
+// ListTasks returns service tasks for realtime container status rendering.
+func (m *ServiceManager) ListTasks(ctx context.Context, serviceRef ServiceReference) ([]ServiceTask, error) {
 	fullServiceName := serviceRef.Name()
 
 	tasks, err := m.dockerClient.TaskList(ctx, dockerswarm.TaskListOptions{
@@ -142,9 +142,9 @@ func (m *ServiceManager) Realtime(ctx context.Context, serviceRef ServiceReferen
 		return nil, fmt.Errorf("list tasks for service %s: %w", fullServiceName, err)
 	}
 
-	out := make([]ServiceTaskRealtime, 0, len(tasks))
+	out := make([]ServiceTask, 0, len(tasks))
 	for _, task := range tasks {
-		out = append(out, ServiceTaskRealtime{
+		out = append(out, ServiceTask{
 			ID:           task.ID,
 			Node:         task.NodeID,
 			CurrentState: string(task.Status.State),

--- a/internal/swarm/service_manager.go
+++ b/internal/swarm/service_manager.go
@@ -147,6 +147,8 @@ func (m *ServiceManager) ListTasks(ctx context.Context, serviceRef ServiceRefere
 		out = append(out, ServiceTask{
 			ID:           task.ID,
 			Node:         task.NodeID,
+			CreatedAt:    task.CreatedAt,
+			UpdatedAt:    task.UpdatedAt,
 			CurrentState: string(task.Status.State),
 			Error:        task.Status.Err,
 		})

--- a/ui/src/api/overview.ts
+++ b/ui/src/api/overview.ts
@@ -4,6 +4,7 @@ import type {
   GitCommitDetailsResponse,
   QueueResponse,
   ServiceDeploymentsResponse,
+  ServiceRealtimeResponse,
   ServiceStatusResponse,
   StacksResponse,
 } from "./types";
@@ -44,4 +45,10 @@ export function fetchServiceDeployments(
   return apiRequest<ServiceDeploymentsResponse>(
     `/api/v1/stacks/${encodedStack}/services/${encodedService}/deployments${query}`,
   );
+}
+
+export function fetchServiceRealtime(stackName: string, serviceName: string): Promise<ServiceRealtimeResponse> {
+  const encodedStack = encodeURIComponent(stackName);
+  const encodedService = encodeURIComponent(serviceName);
+  return apiRequest<ServiceRealtimeResponse>(`/api/v1/stacks/${encodedStack}/services/${encodedService}/realtime`);
 }

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -115,6 +115,9 @@ export interface ServiceStatusResponse {
 export interface ServiceRealtimeTask {
   id: string;
   node: string;
+  node_name?: string;
+  created_at?: string;
+  updated_at?: string;
   current_state: string;
   error?: string;
 }

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -112,6 +112,17 @@ export interface ServiceStatusResponse {
   spec: ServiceSpecResponse;
 }
 
+export interface ServiceRealtimeTask {
+  id: string;
+  node: string;
+  current_state: string;
+  error?: string;
+}
+
+export interface ServiceRealtimeResponse {
+  tasks: ServiceRealtimeTask[];
+}
+
 export type ServiceDeploymentStatus = "success" | "failed";
 
 export interface ServiceDeploymentResponse {

--- a/ui/src/views/ServiceView.vue
+++ b/ui/src/views/ServiceView.vue
@@ -100,6 +100,33 @@ function deploymentKey(item: ServiceDeploymentResponse, index: number): string {
   return `${item.created_at}-${item.status}-${item.image_version}-${index}`;
 }
 
+async function copyTaskID(taskID: string): Promise<void> {
+  const id = String(taskID || "").trim();
+  if (!id) {
+    return;
+  }
+
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(id);
+      return;
+    } catch {
+      // Fall back to legacy clipboard API when browser blocks navigator.clipboard.
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = id;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+}
+
 async function openCommitDetails(commitHash: string | undefined): Promise<void> {
   const hash = String(commitHash || "").trim();
   if (!hash) {
@@ -237,125 +264,169 @@ watch(
     </div>
 
     <div v-else class="service-details-layout">
-      <article class="stack-card service-details-card">
-        <h3 class="stack-title">Service</h3>
-        <table class="service-status-summary-table" aria-label="Service details">
-          <tbody>
-            <tr>
-              <th scope="row">Name</th>
-              <td>{{ serviceInfo?.name || serviceName }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Stack</th>
-              <td>{{ serviceInfo?.stack || stackName }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Type</th>
-              <td>{{ serviceInfo?.type_title || serviceInfo?.type || "n/a" }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Description</th>
-              <td>{{ serviceInfo?.description || "n/a" }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Image</th>
-              <td>{{ serviceInfo?.image || serviceSpec?.image || "n/a" }}</td>
-            </tr>
-            <tr v-if="serviceInfo && serviceInfo.repository_url">
-              <th scope="row">Repository</th>
-              <td>
-                <a
-                  :href="serviceInfo.repository_url"
-                  class="assistant-md-link"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {{ serviceInfo.repository_url }}
-                </a>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Web Routes</th>
-              <td>
-                <ul v-if="serviceRoutes.length > 0" class="service-details-tags">
-                  <li v-for="routeItem in serviceRoutes" :key="`${routeItem.domain}-${routeItem.address}-${routeItem.port}`">
-                    {{ routeItem.domain }} ({{ routeItem.address }}:{{ routeItem.port }})
-                  </li>
-                </ul>
-                <span v-else>n/a</span>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Labels</th>
-              <td>
-                <ul v-if="customServiceLabels.length > 0" class="event-details">
-                  <li v-for="[key, value] in customServiceLabels" :key="key" class="event-detail">
-                    <span class="event-detail-key">{{ key }}</span>
-                    <code class="event-detail-value">{{ value }}</code>
-                  </li>
-                </ul>
-                <span v-else class="meta">No labels.</span>
-              </td>
-            </tr>
-            <tr v-if="dockerServiceLabels.length > 0">
-              <th scope="row">Docker Labels</th>
-              <td>
-                <ul class="event-details">
-                  <li class="event-detail">
-                    <button
-                      type="button"
-                      class="service-secret-badge status unknown"
-                      :aria-expanded="showDockerLabels ? 'true' : 'false'"
-                      @click="toggleDockerLabels"
-                    >
-                      {{ showDockerLabels ? "Hide" : "Show" }}
-                    </button>
-                  </li>
-                </ul>
-                <ul
-                  v-if="showDockerLabels"
-                  class="event-details service-details-docker-tags"
-                >
-                  <li v-for="[key, value] in dockerServiceLabels" :key="key" class="event-detail">
-                    <span class="event-detail-key">{{ key }}</span>
-                    <code class="event-detail-value">{{ value }}</code>
-                  </li>
-                </ul>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Networks</th>
-              <td>
-                <ul v-if="serviceNetworkNames.length > 0" class="service-details-tags">
-                  <li v-for="networkName in serviceNetworkNames" :key="networkName">
-                    {{ networkName }}
-                  </li>
-                </ul>
-                <span v-else>n/a</span>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Secrets</th>
-              <td>
-                <ul v-if="serviceSecrets.length > 0" class="service-details-tags service-secrets-list">
-                  <li v-for="secret in serviceSecrets" :key="`${secret.secret_name}-${secret.secret_id}`">
-                    <button
-                      type="button"
-                      class="service-secret-badge status unknown"
-                      :disabled="!secret.secret_name"
-                      @click="secret.secret_name && openSecretDetails(secret.secret_name)"
-                    >
-                      {{ secret.secret_name || "n/a" }}
-                    </button>
-                  </li>
-                </ul>
-                <span v-else>n/a</span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p v-if="loadingError" class="meta">Warning: {{ loadingError }}</p>
-      </article>
+      <div class="service-details-main">
+        <article class="stack-card service-details-card">
+          <h3 class="stack-title">Service</h3>
+          <table class="service-status-summary-table" aria-label="Service details">
+            <tbody>
+              <tr>
+                <th scope="row">Name</th>
+                <td>{{ serviceInfo?.name || serviceName }}</td>
+              </tr>
+              <tr>
+                <th scope="row">Stack</th>
+                <td>{{ serviceInfo?.stack || stackName }}</td>
+              </tr>
+              <tr>
+                <th scope="row">Type</th>
+                <td>{{ serviceInfo?.type_title || serviceInfo?.type || "n/a" }}</td>
+              </tr>
+              <tr>
+                <th scope="row">Description</th>
+                <td>{{ serviceInfo?.description || "n/a" }}</td>
+              </tr>
+              <tr>
+                <th scope="row">Image</th>
+                <td>{{ serviceInfo?.image || serviceSpec?.image || "n/a" }}</td>
+              </tr>
+              <tr v-if="serviceInfo && serviceInfo.repository_url">
+                <th scope="row">Repository</th>
+                <td>
+                  <a
+                    :href="serviceInfo.repository_url"
+                    class="assistant-md-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {{ serviceInfo.repository_url }}
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Web Routes</th>
+                <td>
+                  <ul v-if="serviceRoutes.length > 0" class="service-details-tags">
+                    <li v-for="routeItem in serviceRoutes" :key="`${routeItem.domain}-${routeItem.address}-${routeItem.port}`">
+                      {{ routeItem.domain }} ({{ routeItem.address }}:{{ routeItem.port }})
+                    </li>
+                  </ul>
+                  <span v-else>n/a</span>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Labels</th>
+                <td>
+                  <ul v-if="customServiceLabels.length > 0" class="event-details">
+                    <li v-for="[key, value] in customServiceLabels" :key="key" class="event-detail">
+                      <span class="event-detail-key">{{ key }}</span>
+                      <code class="event-detail-value">{{ value }}</code>
+                    </li>
+                  </ul>
+                  <span v-else class="meta">No labels.</span>
+                </td>
+              </tr>
+              <tr v-if="dockerServiceLabels.length > 0">
+                <th scope="row">Docker Labels</th>
+                <td>
+                  <ul class="event-details">
+                    <li class="event-detail">
+                      <button
+                        type="button"
+                        class="service-secret-badge status unknown"
+                        :aria-expanded="showDockerLabels ? 'true' : 'false'"
+                        @click="toggleDockerLabels"
+                      >
+                        {{ showDockerLabels ? "Hide" : "Show" }}
+                      </button>
+                    </li>
+                  </ul>
+                  <ul
+                    v-if="showDockerLabels"
+                    class="event-details service-details-docker-tags"
+                  >
+                    <li v-for="[key, value] in dockerServiceLabels" :key="key" class="event-detail">
+                      <span class="event-detail-key">{{ key }}</span>
+                      <code class="event-detail-value">{{ value }}</code>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Networks</th>
+                <td>
+                  <ul v-if="serviceNetworkNames.length > 0" class="service-details-tags">
+                    <li v-for="networkName in serviceNetworkNames" :key="networkName">
+                      {{ networkName }}
+                    </li>
+                  </ul>
+                  <span v-else>n/a</span>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Secrets</th>
+                <td>
+                  <ul v-if="serviceSecrets.length > 0" class="service-details-tags service-secrets-list">
+                    <li v-for="secret in serviceSecrets" :key="`${secret.secret_name}-${secret.secret_id}`">
+                      <button
+                        type="button"
+                        class="service-secret-badge status unknown"
+                        :disabled="!secret.secret_name"
+                        @click="secret.secret_name && openSecretDetails(secret.secret_name)"
+                      >
+                        {{ secret.secret_name || "n/a" }}
+                      </button>
+                    </li>
+                  </ul>
+                  <span v-else>n/a</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-if="loadingError" class="meta">Warning: {{ loadingError }}</p>
+        </article>
+
+        <article class="stack-card service-realtime-card">
+          <h3 class="stack-title">Realtime</h3>
+          <p v-if="realtimeLoading" class="meta">Loading realtime...</p>
+          <p v-else-if="realtimeError" class="meta">Failed to load realtime: {{ realtimeError }}</p>
+          <p v-else-if="realtime.length === 0" class="meta">No tasks yet.</p>
+          <table v-else class="service-status-summary-table service-realtime-table" aria-label="Service realtime">
+            <thead>
+              <tr><th>ID</th><th>Node Name</th><th>Current State</th><th>Created At</th><th>Updated At</th><th>Error</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="task in realtime" :key="task.id">
+                <td class="service-realtime-copy-cell">
+                  <button
+                    type="button"
+                    class="service-copy-task-id-button"
+                    :disabled="!task.id"
+                    :aria-label="`Copy task ID ${task.id}`"
+                    title="Copy task ID"
+                    @click="copyTaskID(task.id)"
+                  >
+                    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                      <path
+                        d="M5 1.5A1.5 1.5 0 0 0 3.5 3v7A1.5 1.5 0 0 0 5 11.5h7A1.5 1.5 0 0 0 13.5 10V3A1.5 1.5 0 0 0 12 1.5H5Zm0 1h7a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-.5.5H5a.5.5 0 0 1-.5-.5V3a.5.5 0 0 1 .5-.5Z"
+                        fill="currentColor"
+                      />
+                      <path
+                        d="M2 4.5a.5.5 0 0 1 .5.5V12A1.5 1.5 0 0 0 4 13.5h7a.5.5 0 0 1 0 1H4A2.5 2.5 0 0 1 1.5 12V5a.5.5 0 0 1 .5-.5Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                </td>
+                <td><code>{{ task.node_name || task.node || 'n/a' }}</code></td>
+                <td>{{ task.current_state || 'n/a' }}</td>
+                <td>{{ formatDate(task.created_at) }}</td>
+                <td>{{ formatDate(task.updated_at) }}</td>
+                <td>{{ task.error || 'n/a' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+      </div>
 
       <div class="service-details-side">
         <article class="stack-card service-resources-card">
@@ -379,26 +450,6 @@ watch(
         </article>
 
 
-
-        <article class="stack-card service-realtime-card">
-          <h3 class="stack-title">Realtime</h3>
-          <p v-if="realtimeLoading" class="meta">Loading realtime...</p>
-          <p v-else-if="realtimeError" class="meta">Failed to load realtime: {{ realtimeError }}</p>
-          <p v-else-if="realtime.length === 0" class="meta">No tasks yet.</p>
-          <table v-else class="service-status-summary-table" aria-label="Service realtime">
-            <thead>
-              <tr><th>ID</th><th>Node</th><th>Current State</th><th>Error</th></tr>
-            </thead>
-            <tbody>
-              <tr v-for="task in realtime" :key="task.id">
-                <td><code>{{ task.id }}</code></td>
-                <td><code>{{ task.node || 'n/a' }}</code></td>
-                <td>{{ task.current_state || 'n/a' }}</td>
-                <td>{{ task.error || 'n/a' }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </article>
 
         <article class="stack-card service-deployments-card">
           <h3 class="stack-title">Latest deployments</h3>

--- a/ui/src/views/ServiceView.vue
+++ b/ui/src/views/ServiceView.vue
@@ -2,11 +2,12 @@
 import { computed, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
-import { fetchServiceDeployments, fetchServiceStatus } from "../api/overview";
+import { fetchServiceDeployments, fetchServiceRealtime, fetchServiceStatus } from "../api/overview";
 import { fetchServices } from "../api/services";
 import type {
   ServiceDeploymentResponse,
   ServiceInfo,
+  ServiceRealtimeTask,
   ServiceStatusResponse,
 } from "../api/types";
 import { useOverviewStore } from "../stores/overview";
@@ -22,6 +23,9 @@ const serviceStatus = ref<ServiceStatusResponse | null>(null);
 const serviceDeployments = ref<ServiceDeploymentResponse[]>([]);
 const deploymentsLoading = ref(false);
 const deploymentsError = ref("");
+const realtimeTasks = ref<ServiceRealtimeTask[]>([]);
+const realtimeLoading = ref(false);
+const realtimeError = ref("");
 const showDockerLabels = ref(false);
 const secretDetailsStore = useSecretDetailsStore();
 const overviewStore = useOverviewStore();
@@ -74,6 +78,11 @@ const serviceNetworkNames = computed(() => {
 });
 const deployments = computed(() => {
   const items = serviceDeployments.value;
+  return Array.isArray(items) ? items : [];
+});
+
+const realtime = computed(() => {
+  const items = realtimeTasks.value;
   return Array.isArray(items) ? items : [];
 });
 
@@ -160,6 +169,27 @@ async function loadServiceDetails() {
   }
 }
 
+
+async function loadServiceRealtime() {
+  if (!stackName.value || !serviceName.value) {
+    realtimeTasks.value = [];
+    realtimeError.value = "Invalid service route parameters";
+    return;
+  }
+
+  realtimeLoading.value = true;
+  realtimeError.value = "";
+  try {
+    const response = await fetchServiceRealtime(stackName.value, serviceName.value);
+    realtimeTasks.value = Array.isArray(response.tasks) ? response.tasks : [];
+  } catch (error) {
+    realtimeTasks.value = [];
+    realtimeError.value = error instanceof Error ? error.message : "Failed to load service realtime";
+  } finally {
+    realtimeLoading.value = false;
+  }
+}
+
 async function loadServiceDeployments() {
   if (!stackName.value || !serviceName.value) {
     serviceDeployments.value = [];
@@ -186,6 +216,7 @@ watch(
     showDockerLabels.value = false;
     void loadServiceDetails();
     void loadServiceDeployments();
+    void loadServiceRealtime();
   },
   { immediate: true },
 );
@@ -342,6 +373,28 @@ watch(
               <tr>
                 <th scope="row">Requested / limited CPU</th>
                 <td>{{ serviceSpec?.requested_cpu_nano ? formatNanoCPU(serviceSpec?.requested_cpu_nano) : 0 }} / {{ serviceSpec?.limit_cpu_nano? formatNanoCPU(serviceSpec?.limit_cpu_nano) : '∞' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+
+
+        <article class="stack-card service-realtime-card">
+          <h3 class="stack-title">Realtime</h3>
+          <p v-if="realtimeLoading" class="meta">Loading realtime...</p>
+          <p v-else-if="realtimeError" class="meta">Failed to load realtime: {{ realtimeError }}</p>
+          <p v-else-if="realtime.length === 0" class="meta">No tasks yet.</p>
+          <table v-else class="service-status-summary-table" aria-label="Service realtime">
+            <thead>
+              <tr><th>ID</th><th>Node</th><th>Current State</th><th>Error</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="task in realtime" :key="task.id">
+                <td><code>{{ task.id }}</code></td>
+                <td><code>{{ task.node || 'n/a' }}</code></td>
+                <td>{{ task.current_state || 'n/a' }}</td>
+                <td>{{ task.error || 'n/a' }}</td>
               </tr>
             </tbody>
           </table>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -235,6 +235,13 @@ button:hover,
   align-items: start;
 }
 
+.service-details-main {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  min-width: 0;
+}
+
 .service-details-card {
   min-width: 0;
 }
@@ -1018,6 +1025,73 @@ button:hover,
 .service-status-summary-table td {
   overflow-wrap: anywhere;
   word-break: break-word;
+}
+
+.service-realtime-table th {
+  width: auto;
+}
+
+.service-realtime-table th:nth-child(1),
+.service-realtime-table td:nth-child(1) {
+  width: 56px;
+  text-align: center;
+}
+
+.service-realtime-table th:nth-child(2),
+.service-realtime-table td:nth-child(2) {
+  width: 18%;
+}
+
+.service-realtime-table th:nth-child(3),
+.service-realtime-table td:nth-child(3) {
+  width: 14%;
+}
+
+.service-realtime-table th:nth-child(4),
+.service-realtime-table td:nth-child(4) {
+  width: 14%;
+}
+
+.service-realtime-table th:nth-child(5),
+.service-realtime-table td:nth-child(5) {
+  width: 14%;
+}
+
+.service-realtime-table th:nth-child(6),
+.service-realtime-table td:nth-child(6) {
+  width: 40%;
+}
+
+.service-realtime-copy-cell {
+  white-space: nowrap;
+}
+
+.service-copy-task-id-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  color: var(--text);
+  background: rgba(161, 192, 204, 0.12);
+  border: 1px solid rgba(161, 192, 204, 0.3);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.service-copy-task-id-button:hover {
+  background: rgba(161, 192, 204, 0.2);
+}
+
+.service-copy-task-id-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.service-copy-task-id-button svg {
+  width: 14px;
+  height: 14px;
 }
 
 .service-status-link-panel {


### PR DESCRIPTION
### Motivation

- Provide a realtime view of service tasks so the UI can show current container/task states per service for faster troubleshooting.

### Description

- Added new OpenAPI path `/api/v1/stacks/{stack}/services/{service}/realtime` and corresponding schema `ServiceRealtimeResponse` and `ServiceRealtimeTask` in `api/api-server.yaml` and regenerated server/client code. 
- Implemented server-side support including request decoding/encoding, routing, tracing/metrics, and an unimplemented handler stub in the generated API surface. 
- Implemented handler `GetServiceRealtime` that uses the `ServiceStatusInspector.Realtime` method and returns `ServiceRealtimeResponse` with proper HTTP error translation. 
- Extended the swarm layer with `ServiceTaskRealtime` type and `ServiceManager.Realtime` implementation that lists Docker tasks (`TaskList` with a service filter) and maps them to the realtime model. 
- Updated the handlers layer: added `ServiceStatusInspector.Realtime` to the interface, mapper `toGeneratedServiceRealtimeTasks`, and related JSON encode/decode/validation bindings in generated code. 
- Updated UI client and view: added `fetchServiceRealtime` API call, TypeScript types for realtime tasks, invoked realtime loading from `ServiceView.vue`, and added a realtime table to the service details pane.
- Small test adjustment to the fake inspector used in `get_service_status_test.go` to satisfy the new interface.

### Testing

- Ran Go unit tests for the webserver handlers package with `go test ./internal/entrypoints/webserver/...`, which completed successfully.
- Ran the full Go test suite with `go test ./...`, which completed successfully for the modified packages.
- Built the frontend with `npm run build` in the UI directory to validate TypeScript and template changes, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a176457cca48332912a08601569347c)